### PR TITLE
Add Docker compose setup

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -1,0 +1,12 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirement.txt ./
+RUN pip install --no-cache-dir -r requirement.txt
+
+COPY backend ./backend
+
+EXPOSE 8000
+
+CMD ["uvicorn", "backend.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -1,0 +1,23 @@
+# Build stage
+FROM node:20 AS build
+WORKDIR /app
+
+# Install dependencies
+COPY package.json package-lock.json ./
+RUN npm ci
+
+# Copy source
+COPY index.html vite.config.js .
+COPY public ./public
+COPY src ./src
+
+# Build with VITE_BACKEND_URL passed as build argument
+ARG VITE_BACKEND_URL
+ENV VITE_BACKEND_URL=$VITE_BACKEND_URL
+RUN npm run build
+
+# Runtime stage
+FROM nginx:alpine
+COPY --from=build /app/dist /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/README.md
+++ b/README.md
@@ -54,6 +54,18 @@ The application will then:
     ```
     The frontend will be accessible at `http://localhost:5173` (or another port if 5173 is busy - check your terminal output).
 
+### Docker Compose
+
+The project includes a `docker-compose.yml` file to simplify running both the
+backend and frontend using Docker. Build and start the containers with:
+
+```bash
+docker compose up --build
+```
+
+This will expose the backend at `http://localhost:8000` and the frontend at
+`http://localhost:5173`.
+
 ## Project Structure
 
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '3.8'
+services:
+  backend:
+    build:
+      context: .
+      dockerfile: Dockerfile.backend
+    ports:
+      - "8000:8000"
+
+  frontend:
+    build:
+      context: .
+      dockerfile: Dockerfile.frontend
+      args:
+        VITE_BACKEND_URL: http://backend:8000
+    ports:
+      - "5173:80"
+    depends_on:
+      - backend

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -24,6 +24,11 @@ const CHART_COLORS = {
   other: '#95A5A6'     // Gray for other percentiles
 };
 
+// Base URL for the backend API. When running inside Docker this will be
+// injected at build time via VITE_BACKEND_URL. Fallback to relative path for
+// local development without Docker.
+const API_BASE_URL = import.meta.env.VITE_BACKEND_URL || '';
+
 // Helper to format a number as lakh/crore for input display
 const formatINRInput = (value) => {
   if (value === '' || value === null || isNaN(value)) return '';
@@ -126,7 +131,7 @@ function App() {
     setError(null);
     setSimulationData(null);
     try {
-      const response = await fetch('https://wealthcast-production.up.railway.app:8000/api/simulate', {
+      const response = await fetch(`${API_BASE_URL}/api/simulate`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(form)


### PR DESCRIPTION
## Summary
- add Dockerfiles for backend and frontend
- add docker-compose for local deployment
- update React app to use an env variable for backend API
- document Docker usage in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_b_684a280bb7d483269cf05f6a5aeb8ab2