### PR TITLE
Fix tests to include monthly expense field

### DIFF
--- a/backend/test_main.py
+++ b/backend/test_main.py
@@ -20,7 +20,8 @@ class TestMonteCarloSimulation(unittest.TestCase):
             "return_std_dev_pct": 12.0,
             "inflation_pct": 2.5,
             "inflation_std_dev_pct": 1.0,
-            "num_simulations": 50  # Smaller number for faster tests
+            "num_simulations": 50,  # Smaller number for faster tests
+            "current_monthly_expense": 1000.0
         }
     
     def test_root_endpoint(self):

--- a/requirement.txt
+++ b/requirement.txt
@@ -13,3 +13,5 @@ starlette==0.46.2
 typing-extensions==4.14.0
 typing-inspection==0.4.1
 uvicorn==0.34.3
+
+httpx==0.27.0


### PR DESCRIPTION
## Summary
- include `current_monthly_expense` in test inputs

## Testing
- `PYTHONPATH=.venv/lib/python3.12/site-packages pytest backend/test_main.py -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_b_684dc477a85c8326a45bbb799b1de428