### PR TITLE
Add probability note and age-based labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ WealthCast is a modern financial scenario analyzer that uses Monte Carlo simulat
 
 - **Monte Carlo Simulation:** Project your portfolio's future value under uncertainty.
 - **Percentile Visualization:** See 5th, 25th, 50th (median), 75th, and 95th percentiles.
-- **Depletion Probability:** Backend computes the chance your portfolio hits zero before your planned age at death.
+- **Depletion Probability:** Backend computes the chance your portfolio hits zero before your end of life.
 - **Expense Modeling:** Account for inflation-adjusted expenses in your retirement plan.
 - **Indian Rupee Support:** All values in ₹, with lakh/crore formatting.
 - **Interactive UI:** Toggle traces, adjust parameters, and see results instantly.

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ WealthCast is a modern financial scenario analyzer that uses Monte Carlo simulat
 
 - **Monte Carlo Simulation:** Project your portfolio's future value under uncertainty.
 - **Percentile Visualization:** See 5th, 25th, 50th (median), 75th, and 95th percentiles.
-- **Depletion Probability:** Backend computes the chance your portfolio hits zero before your life expectancy.
+- **Depletion Probability:** Backend computes the chance your portfolio hits zero before your planned age at death.
 - **Expense Modeling:** Account for inflation-adjusted expenses in your retirement plan.
 - **Indian Rupee Support:** All values in ₹, with lakh/crore formatting.
 - **Interactive UI:** Toggle traces, adjust parameters, and see results instantly.
-- **Flexible Timeline:** Enter your retirement year and how many years you expect retirement to last.
+- **Flexible Timeline:** Enter your retirement age and your expected age at death.
 - **Docker & Railway Ready:** Easy to deploy locally or in the cloud.
 
 ---

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ WealthCast is a modern financial scenario analyzer that uses Monte Carlo simulat
 - **Expense Modeling:** Account for inflation-adjusted expenses in your retirement plan.
 - **Indian Rupee Support:** All values in ₹, with lakh/crore formatting.
 - **Interactive UI:** Toggle traces, adjust parameters, and see results instantly.
+- **Flexible Timeline:** Enter your retirement year and how many years you expect retirement to last.
 - **Docker & Railway Ready:** Easy to deploy locally or in the cloud.
 
 ---

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ WealthCast is a modern financial scenario analyzer that uses Monte Carlo simulat
 
 - **Monte Carlo Simulation:** Project your portfolio's future value under uncertainty.
 - **Percentile Visualization:** See 5th, 25th, 50th (median), 75th, and 95th percentiles.
+- **Depletion Probability:** Backend computes the chance your portfolio hits zero before your target age.
 - **Expense Modeling:** Account for inflation-adjusted expenses in your retirement plan.
 - **Indian Rupee Support:** All values in ₹, with lakh/crore formatting.
 - **Interactive UI:** Toggle traces, adjust parameters, and see results instantly.
@@ -76,6 +77,7 @@ npm run dev
 
 - **Frontend:** React + Vite, Recharts for visualization, INR formatting.
 - **Backend:** FastAPI, NumPy for simulation, CORS enabled.
+- **Simulation Output:** `/api/simulate` now returns a `ruin_probability` field (percentage).
 - **Testing:** Backend unit tests in `backend/test_main.py`.
 - **Linting:** Python code is linted with [Ruff](https://github.com/astral-sh/ruff); JavaScript/TypeScript is linted with ESLint.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ WealthCast is a modern financial scenario analyzer that uses Monte Carlo simulat
 
 - **Monte Carlo Simulation:** Project your portfolio's future value under uncertainty.
 - **Percentile Visualization:** See 5th, 25th, 50th (median), 75th, and 95th percentiles.
-- **Depletion Probability:** Backend computes the chance your portfolio hits zero before your target age.
+- **Depletion Probability:** Backend computes the chance your portfolio hits zero before your life expectancy.
 - **Expense Modeling:** Account for inflation-adjusted expenses in your retirement plan.
 - **Indian Rupee Support:** All values in ₹, with lakh/crore formatting.
 - **Interactive UI:** Toggle traces, adjust parameters, and see results instantly.

--- a/backend/test_main.py
+++ b/backend/test_main.py
@@ -36,6 +36,9 @@ class TestMonteCarloSimulation(unittest.TestCase):
         self.assertIn("paths", data)
         self.assertIn("years", data)
         self.assertIn("percentiles", data)
+        self.assertIn("ruin_probability", data)
+        self.assertGreaterEqual(data["ruin_probability"], 0)
+        self.assertLessEqual(data["ruin_probability"], 100)
         for key in ["median", "p25", "p75", "p5", "p95"]:
             self.assertIn(key, data["percentiles"])
             self.assertEqual(len(data["percentiles"][key]), self.valid_input["end_year"] - self.valid_input["start_year"] + 1)

--- a/src/App.css
+++ b/src/App.css
@@ -132,9 +132,10 @@
 }
 
 .probability-note {
-  margin-top: 0.5em;
-  font-size: 0.9em;
-  color: #ccc;
+  margin-top: 0.75em;
+  font-size: 1em;
+  color: #333;
+  font-weight: 600;
   text-align: left;
 }
 

--- a/src/App.css
+++ b/src/App.css
@@ -131,6 +131,13 @@
   margin: 1em 0;
 }
 
+.probability-note {
+  margin-top: 0.5em;
+  font-size: 0.9em;
+  color: #ccc;
+  text-align: left;
+}
+
 @media (max-width: 1024px) {
   .main-content {
     flex-direction: column;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -56,7 +56,7 @@ function App() {
     initial_corpus: 40000000, // 4 Cr
     current_monthly_expense: 250000, // 2.5 L
     start_year: 2025,
-    end_year: 2079,
+    life_expectancy: 54,
     expected_return_pct: 12.0,
     return_std_dev_pct: 9.0,
     inflation_pct: 6.0,
@@ -149,10 +149,14 @@ function App() {
     setError(null);
     setSimulationData(null);
     try {
+      const payload = {
+        ...form,
+        end_year: form.start_year + form.life_expectancy
+      };
       const response = await fetch(`${backendUrl}/api/simulate`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(form)
+        body: JSON.stringify(payload)
       });
       if (!response.ok) {
         throw new Error(`HTTP error! status: ${response.status}`);
@@ -185,9 +189,9 @@ function App() {
   };
 
   // Helper to map simulation points to actual ages
-  const getAge = (index) => form.start_year + index;
+  const getAge = (index) => index;
 
-  // Helper to map a percentile/path array to actual ages
+  // Helper to map a percentile/path array to age values
   const mapToActualYears = (arr) => arr.map((pt, idx) => ({ ...pt, year: getAge(idx) }));
 
   // Helper to get Y-axis domain as a new array
@@ -243,7 +247,7 @@ function App() {
             </label>
             <label>
               Life Expectancy (years):
-              <input type="number" name="end_year" value={form.end_year} onChange={handleChange} min={form.start_year} max={2100} required />
+              <input type="number" name="life_expectancy" value={form.life_expectancy} onChange={handleChange} min={1} max={100} required />
             </label>
             <label>
               Expected Return (%):
@@ -339,8 +343,8 @@ function App() {
                   <XAxis
                     dataKey="year"
                     type="number"
-                    domain={[form.start_year, form.end_year]}
-                    tickCount={form.end_year - form.start_year + 1}
+                    domain={[0, form.life_expectancy]}
+                    tickCount={form.life_expectancy + 1}
                     label={{ value: 'Age', position: 'insideBottomRight', offset: -5 }}
                   />
                   <YAxis

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -55,8 +55,8 @@ function App() {
   const [form, setForm] = useState({
     initial_corpus: 40000000, // 4 Cr
     current_monthly_expense: 250000, // 2.5 L
-    start_year: 2025,
-    life_expectancy: 54,
+    retirement_age: 60,
+    age_at_death: 90,
     expected_return_pct: 12.0,
     return_std_dev_pct: 9.0,
     inflation_pct: 6.0,
@@ -149,9 +149,11 @@ function App() {
     setError(null);
     setSimulationData(null);
     try {
+      const { retirement_age, age_at_death, ...rest } = form;
       const payload = {
-        ...form,
-        end_year: form.start_year + form.life_expectancy
+        ...rest,
+        start_year: retirement_age,
+        end_year: age_at_death
       };
       const response = await fetch(`${backendUrl}/api/simulate`, {
         method: 'POST',
@@ -189,7 +191,7 @@ function App() {
   };
 
   // Helper to map simulation points to actual ages
-  const getAge = (index) => index;
+  const getAge = (index) => form.retirement_age + index;
 
   // Helper to map a percentile/path array to age values
   const mapToActualYears = (arr) => arr.map((pt, idx) => ({ ...pt, year: getAge(idx) }));
@@ -242,12 +244,12 @@ function App() {
               />
             </label>
             <label>
-              Retirement Year:
-              <input type="number" name="start_year" value={form.start_year} onChange={handleChange} min={1900} max={2100} required />
+              Retirement Age:
+              <input type="number" name="retirement_age" value={form.retirement_age} onChange={handleChange} min={40} max={80} required />
             </label>
             <label>
-              Life Expectancy (years):
-              <input type="number" name="life_expectancy" value={form.life_expectancy} onChange={handleChange} min={1} max={100} required />
+              Age at Death:
+              <input type="number" name="age_at_death" value={form.age_at_death} onChange={handleChange} min={form.retirement_age + 1} max={120} required />
             </label>
             <label>
               Expected Return (%):
@@ -343,8 +345,8 @@ function App() {
                   <XAxis
                     dataKey="year"
                     type="number"
-                    domain={[0, form.life_expectancy]}
-                    tickCount={form.life_expectancy + 1}
+                    domain={[form.retirement_age, form.age_at_death]}
+                    tickCount={form.age_at_death - form.retirement_age + 1}
                     label={{ value: 'Age', position: 'insideBottomRight', offset: -5 }}
                   />
                   <YAxis
@@ -475,7 +477,7 @@ function App() {
               {ruinProbability !== null && (
                 <p className="probability-note">
                   Based on these simulations, there is a {ruinProbability.toFixed(1)}% chance that
-                  your portfolio will be depleted before your life expectancy.
+                  your portfolio will be depleted before your planned age at death.
                 </p>
               )}
             </div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -238,12 +238,12 @@ function App() {
               />
             </label>
             <label>
-              Retirement Age:
-              <input type="number" name="start_year" value={form.start_year} onChange={handleChange} min={0} max={150} required />
+              Retirement Year:
+              <input type="number" name="start_year" value={form.start_year} onChange={handleChange} min={1900} max={2100} required />
             </label>
             <label>
-              Age at Death:
-              <input type="number" name="end_year" value={form.end_year} onChange={handleChange} min={form.start_year} max={150} required />
+              Life Expectancy (years):
+              <input type="number" name="end_year" value={form.end_year} onChange={handleChange} min={form.start_year} max={2100} required />
             </label>
             <label>
               Expected Return (%):
@@ -471,7 +471,7 @@ function App() {
               {ruinProbability !== null && (
                 <p className="probability-note">
                   Based on these simulations, there is a {ruinProbability.toFixed(1)}% chance that
-                  your portfolio will be depleted before your target age of death.
+                  your portfolio will be depleted before your life expectancy.
                 </p>
               )}
             </div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -477,7 +477,7 @@ function App() {
               {ruinProbability !== null && (
                 <p className="probability-note">
                   Based on these simulations, there is a {ruinProbability.toFixed(1)}% chance that
-                  your portfolio will be depleted before your planned age at death.
+                  your portfolio will be depleted before your end of life.
                 </p>
               )}
             </div>


### PR DESCRIPTION
## Summary
- show probability of portfolio depletion under simulation chart
- rename start/end year fields to retirement age & age at death
- label axis and tooltip as "Age"
- compute depletion probability server-side and expose in API
- document new field in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_b_684f48c437e48326a2e6e7cfb2a90074